### PR TITLE
Updates for media/queue

### DIFF
--- a/lib/Marlin/Marlin/src/gcode/queue.h
+++ b/lib/Marlin/Marlin/src/gcode/queue.h
@@ -112,6 +112,11 @@ public:
     inline uint32_t get_current_sdpos() {
         return length ? sdpos_buffer[index_r] : sdpos;
     }
+
+    // Set the file position of the _current_ instruction
+    inline void set_current_sdpos(uint32_t pos) {
+      sdpos = sdpos;
+    }
 #endif
   };
 
@@ -130,6 +135,11 @@ public:
    * Return the file position of the _current_ instruction
    */
   static uint32_t get_current_sdpos() { return ring_buffer.get_current_sdpos(); }
+
+  /**
+   * Return the file position of the _current_ instruction
+   */
+  static void set_current_sdpos(uint32_t pos) { ring_buffer.set_current_sdpos(pos); }
 #endif
 
   /**

--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -1595,8 +1595,8 @@ static void _set_notify_change(uint8_t var_id) {
 }
 
 static void _server_update_gqueue(void) {
-    if (marlin_server.gqueue != queue.length) {
-        marlin_server.gqueue = queue.length;
+    if (marlin_server.gqueue != queue.ring_buffer.length) {
+        marlin_server.gqueue = queue.ring_buffer.length;
         //		_dbg("gqueue: %2d", marlin_server.gqueue);
     }
 }

--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -976,7 +976,7 @@ static void _server_print_loop(void) {
         marlin_server.print_state = mpsPausing_WaitIdle;
         break;
     case mpsPausing_WaitIdle:
-        if ((planner.movesplanned() == 0) && (queue.length == 0) && gcode.busy_state == GcodeSuite::NOT_BUSY) {
+        if ((planner.movesplanned() == 0) && !queue.has_commands_queued() && gcode.busy_state == GcodeSuite::NOT_BUSY) {
             marlin_server_park_head();
             marlin_server.print_state = mpsPausing_ParkHead;
         }
@@ -1019,7 +1019,7 @@ static void _server_print_loop(void) {
         marlin_server.print_state = mpsResuming_UnparkHead_ZE;
         break;
     case mpsResuming_UnparkHead_ZE:
-        if ((planner.movesplanned() != 0) || (queue.length != 0) || (media_print_get_state() != media_print_state_PAUSED))
+        if ((planner.movesplanned() != 0) || queue.has_commands_queued() || (media_print_get_state() != media_print_state_PAUSED))
             break;
 #if ENABLED(CRASH_RECOVERY)
         if (crash_s.get_state() == Crash_s::RECOVERY) {
@@ -1068,7 +1068,7 @@ static void _server_print_loop(void) {
         marlin_server.print_state = mpsAborting_WaitIdle;
         break;
     case mpsAborting_WaitIdle:
-        if ((planner.movesplanned() != 0) || (queue.length != 0))
+        if ((planner.movesplanned() != 0) || queue.has_commands_queued())
             break;
 
         // allow movements again
@@ -1086,7 +1086,7 @@ static void _server_print_loop(void) {
         marlin_server.print_state = mpsAborting_ParkHead;
         break;
     case mpsAborting_ParkHead:
-        if ((planner.movesplanned() == 0) && (queue.length == 0)) {
+        if ((planner.movesplanned() == 0) && !queue.has_commands_queued()) {
             disable_XY();
 #ifndef Z_ALWAYS_ON
             disable_Z();
@@ -1097,7 +1097,7 @@ static void _server_print_loop(void) {
         }
         break;
     case mpsFinishing_WaitIdle:
-        if ((planner.movesplanned() == 0) && (queue.length == 0)) {
+        if ((planner.movesplanned() == 0) && !queue.has_commands_queued()) {
 #if ENABLED(CRASH_RECOVERY)
             // TODO: the following should be moved to mpsFinishing_ParkHead once the "stopping"
             // state is handled properly
@@ -1114,7 +1114,7 @@ static void _server_print_loop(void) {
         }
         break;
     case mpsFinishing_ParkHead:
-        if ((planner.movesplanned() == 0) && (queue.length == 0)) {
+        if ((planner.movesplanned() == 0) && !queue.has_commands_queued()) {
             marlin_server.print_state = mpsFinished;
             marlin_server_finalize_print();
         }
@@ -1174,7 +1174,7 @@ static void _server_print_loop(void) {
         break;
     }
     case mpsCrashRecovery_XY_Measure: {
-        if (queue.length != 0 || planner.movesplanned() != 0)
+        if (queue.has_commands_queued() || planner.movesplanned() != 0)
             break;
 
         static metric_t crash_len = METRIC("crash_length", METRIC_VALUE_CUSTOM, 0, METRIC_HANDLER_ENABLE_ALL);
@@ -1185,7 +1185,7 @@ static void _server_print_loop(void) {
         break;
     }
     case mpsCrashRecovery_XY_HOME: {
-        if (queue.length != 0 || planner.movesplanned() != 0)
+        if (queue.has_commands_queued() || planner.movesplanned() != 0)
             break;
 
         if (!crash_s.is_repeated_crash()) {

--- a/src/common/media.cpp
+++ b/src/common/media.cpp
@@ -277,7 +277,7 @@ void media_print_stop(void) {
     if ((media_print_state == media_print_state_PRINTING) || (media_print_state == media_print_state_PAUSED)) {
         close_file();
         media_print_state = media_print_state_NONE;
-        queue.sdpos = MEDIA_PRINT_UNDEF_POSITION;
+        queue.set_current_sdpos(MEDIA_PRINT_UNDEF_POSITION);
     }
 }
 
@@ -452,7 +452,7 @@ void media_loop(void) {
                 skip_gcode = false;
             } else {
                 // update the gcode position for the queue
-                queue.sdpos = media_gcode_position;
+                queue.set_current_sdpos(media_gcode_position);
                 // FIXME: what if the gcode is not enqueued
                 // use 'enqueue_one_now' instead
                 queue.enqueue_one(gcode, false);

--- a/src/common/media.cpp
+++ b/src/common/media.cpp
@@ -392,7 +392,7 @@ char getByte(GCodeFilter::State *state) {
 void media_loop(void) {
     if (media_print_state == media_print_state_DRAINING) {
         close_file();
-        int index_r = queue.index_r;
+        int index_r = queue.ring_buffer.index_r;
         media_gcode_position = media_current_position = media_queue_position[index_r];
         queue.clear();
         media_print_state = media_print_state_PAUSED;
@@ -411,7 +411,7 @@ void media_loop(void) {
     }
 
     media_loop_read = 0;
-    while (queue.length < (BUFSIZE - 1)) { // Keep one free slot for serial commands
+    while (queue.ring_buffer.length < (BUFSIZE - 1)) { // Keep one free slot for serial commands
         GCodeFilter::State state;
         char *gcode = gcode_filter.nextGcode(&state);
 


### PR DESCRIPTION
Use new queue functions available in Marlin 2.1 when possible, otherwise revert to accessing the queue.ring_buffer directly to synchronize the media queue with Marlin's queue.